### PR TITLE
Use template, not copy, to guarantee idempotency

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,7 +11,7 @@
   tags: [configuration,timezone]
 
 - name: Set /etc/timezone to {{ timezone }}
-  copy: dest=/etc/timezone content="{{ timezone }}"
+  template: dest=/etc/timezone src=timezone.j2
   notify: update tzdata
   when: ansible_os_family == "Debian"
   tags: [configuration,timezone]

--- a/templates/timezone.j2
+++ b/templates/timezone.j2
@@ -1,0 +1,1 @@
+{{ timezone }}


### PR DESCRIPTION
So, this is a bit more finicky than I first thought. Using the copy
module causes problems. If you specify the timezone var as, say,
"Etc/UTC", then the following will happen:
1. Ansible sets the content of /etc/timezone to "Etc/UTC" (with no
   trailing newline), triggering the "update tzdata" handler.
2. "dpkg-reconfigure tzdata" handler will cause the file contents to
   change to "Etc/UTC\n" (i.e. with a trailing newline)
3. On subsequent ansible runs, the hash of the file will not match and
   so it will be updated _again_, triggering steps 1. (and thus, 2.)
   again.

This commit fixes the issue by using a simple template to ensure the
file is created with a trailing newline in the first place. (It seems to
be more-or-less impossible to convince the `content` parameter to the
copy module to accept a literal newline.)
