### PR TITLE
Make permissions explicit

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 # defaults file for timezone
 timezone: UTC
+sudo: no

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,3 +2,5 @@
 # handlers file for timezone
 - name: update tzdata
   command: dpkg-reconfigure --frontend noninteractive tzdata
+  sudo: {{ sudo }}
+

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,6 +7,7 @@
         group=root
         mode=0644
         backup=yes
+  sudo: {{ sudo }}
   when: ansible_os_family == "Debian"
   tags: [configuration,timezone]
 
@@ -17,6 +18,7 @@
             group=root
             mode=0644
             backup=yes
+  sudo: {{ sudo }}
   notify: update tzdata
   when: ansible_os_family == "Debian"
   tags: [configuration,timezone]


### PR DESCRIPTION
The main reason for this pull request was to explicitly set the permissions of /etc/timezone to ensure a reliable and secure result. When I was trying to test the roles was failing because I used vagrant and of course the vagrant user. So I added the ability to use sudo if requested using a parameter.
