### PR TITLE
main.yml: copy local timezone file to /etc/localtime

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,12 +1,7 @@
 ---
 # tasks file for timezone
-- name: Set /etc/localtime to {{ timezone }}
-  copy: src=/usr/share/zoneinfo/{{ timezone }}
-        dest=/etc/localtime
-        owner=root
-        group=root
-        mode=0644
-        backup={{ backup_etc_files }}
+- name: Copy timezone {{ timezone }} to /etc/localtime
+  command: rsync --itemize-changes --checksum --copy-links /usr/share/zoneinfo/{{ timezone }} /etc/localtime
   when: ansible_os_family == "Debian"
   tags: [configuration,timezone]
 


### PR DESCRIPTION
Previous version copied file from host where ansible-playbook is running to remote system. Local and remove hosts may have different versions of tzdata. Copying files on remote host is more correct.